### PR TITLE
Add query string to exported formats

### DIFF
--- a/src/lib/export/exporters/alacritty.ts
+++ b/src/lib/export/exporters/alacritty.ts
@@ -1,13 +1,14 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toAlacritty(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `# Copy the configuration below and add it to your
 # ~/.config/alacritty/alacritty.toml file
 
 # Colors (Root Loops)
-# via rootloops.sh
+# via https://rootloops.sh?${queryString}
 
 [colors.primary]
 background = '${cereals.background.color_hex}'

--- a/src/lib/export/exporters/exporters.test.ts
+++ b/src/lib/export/exporters/exporters.test.ts
@@ -27,7 +27,7 @@ describe("export", () => {
   it("to JSON", () => {
     const config = toJson(someRecipe);
     const expected = {
-      source: "rootloops.sh",
+      source: "https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2",
       hex: {
         background: "#dfe2eb",
         foreground: "#1e222d",
@@ -113,7 +113,7 @@ describe("export", () => {
 # ~/.config/alacritty/alacritty.toml file
 
 # Colors (Root Loops)
-# via rootloops.sh
+# via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
 
 [colors.primary]
 background = '#dfe2eb'
@@ -150,7 +150,7 @@ white = '#07080d'`;
     const config = toXresources(someRecipe);
     // prettier-ignore
     const expected = `! Copy the configuration below to your ~/.Xresources file
-! Root Loops (via rootloops.sh)
+! Root Loops (via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2)
 
 *.foreground:  #1e222d
 *.background:  #dfe2eb
@@ -183,7 +183,7 @@ white = '#07080d'`;
 # ~/.config/kitty/kitty.conf file
 
 ## Root Loops color scheme
-## via https://rootloops.sh
+## via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
 
 # The basic colors
 background              #dfe2eb
@@ -265,7 +265,7 @@ color15 #07080d`;
 --       if you want to define your own root loops color scheme
 
 -- Root Loops color scheme
--- via https://rootloops.sh
+-- via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
 config.colors = {
   foreground = "#1e222d",
   background = "#dfe2eb",
@@ -305,7 +305,7 @@ config.colors = {
     const expected = `# Copy the configuration below to ~/.config/helix/themes/rootloops.toml
 
 
-# Root Loops (https://rootloops.sh)
+# Root Loops (https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2)
 
 "ui.background" = { fg = "background"}
 "ui.background.separator" = { fg = "gray" }
@@ -421,7 +421,7 @@ background = "#dfe2eb"`;
 # ~/.config/ghostty/config file
 
 # Colors (Root Loops)
-# via rootloops.sh
+# via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
 
 background = dfe2eb
 foreground = 1e222d
@@ -469,7 +469,7 @@ palette = 15=#07080d`;
 
 [colors]
 # Root Loops color scheme
-# via https://rootloops.sh
+# via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
 
 background=dfe2eb
 foreground=1e222d
@@ -504,7 +504,7 @@ bright7=07080d # bright white`;
 // ~/.config/zellij/zellij.kdl file
 
 // Colors (Root Loops)
-// via rootloops.sh
+// via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
 themes {
    rootloops {
         fg "#1e222d"
@@ -532,6 +532,7 @@ theme "rootloops"`
     const expected = `# Add the 'export' statement below to your shell's configuration
 # (e.g. ~/.bashrc, ~/.zshrc, or a custom file you load during shell startup)
 
+# Root Loops (https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2)
 export FZF_DEFAULT_OPTS="\
   --color=fg:#1e222d,fg+:#07080d,bg:#dfe2eb,bg+:#d0d4e1 \\
   --color=hl:#374a4d,hl+:#475e62,info:#4b4536,marker:#3c4a3e \\
@@ -955,7 +956,7 @@ Open iTerm2's Settings > Profiles > Color tab and import the file into iTerm2.
 # ~/.warp/themes/rootloops.yaml
 # Open Warp's Settings > Appearance > Themes and select the 'Root Loops' theme.
 
-# via rootloops.sh
+# via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
 
 name: Root Loops
 accent: '#4a5165'

--- a/src/lib/export/exporters/foot.ts
+++ b/src/lib/export/exporters/foot.ts
@@ -1,15 +1,16 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 import { noHash } from "./util";
 
 export function toFoot(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `# Copy the configuration below and add it to your
 # ~/.config/foot/foot.ini file
 
 [colors]
 # Root Loops color scheme
-# via https://rootloops.sh
+# via https://rootloops.sh?${queryString}
 
 background=${noHash(cereals.background.color_hex)}
 foreground=${noHash(cereals.foreground.color_hex)}

--- a/src/lib/export/exporters/fzf.ts
+++ b/src/lib/export/exporters/fzf.ts
@@ -1,11 +1,13 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toFzf(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `# Add the 'export' statement below to your shell's configuration
 # (e.g. ~/.bashrc, ~/.zshrc, or a custom file you load during shell startup)
 
+# Root Loops (https://rootloops.sh?${queryString})
 export FZF_DEFAULT_OPTS="\
   --color=fg:${cereals.foreground.color_hex},fg+:${cereals.brightWhite.color_hex},bg:${cereals.background.color_hex},bg+:${cereals.black.color_hex} \\
   --color=hl:${cereals.cyan.color_hex},hl+:${cereals.brightCyan.color_hex},info:${cereals.yellow.color_hex},marker:${cereals.green.color_hex} \\

--- a/src/lib/export/exporters/ghostty.ts
+++ b/src/lib/export/exporters/ghostty.ts
@@ -1,15 +1,16 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 import { noHash } from "./util";
 
 export function toGhostty(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
 
   return `# Copy the configuration below and add it to your
 # ~/.config/ghostty/config file
 
 # Colors (Root Loops)
-# via rootloops.sh
+# via https://rootloops.sh?${queryString}
 
 background = ${noHash(cereals.background.color_hex)}
 foreground = ${noHash(cereals.foreground.color_hex)}

--- a/src/lib/export/exporters/helix.ts
+++ b/src/lib/export/exporters/helix.ts
@@ -1,12 +1,13 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toHelix(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `# Copy the configuration below to ~/.config/helix/themes/rootloops.toml
 
 
-# Root Loops (https://rootloops.sh)
+# Root Loops (https://rootloops.sh?${queryString})
 
 "ui.background" = { fg = "background"}
 "ui.background.separator" = { fg = "gray" }

--- a/src/lib/export/exporters/iterm.ts
+++ b/src/lib/export/exporters/iterm.ts
@@ -1,8 +1,9 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare, type Cereal } from "$lib/cereals";
 
 export function toITerm(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
 
   console.log(recipe);
 
@@ -27,6 +28,7 @@ Save the configuration below to a file called root-loops.itermcolors.
 Open iTerm2's Settings > Profiles > Color tab and import the file into iTerm2.
 -->
 
+<!-- Root Loops (https://rootloops.sh?${queryString}) -->
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/src/lib/export/exporters/json.ts
+++ b/src/lib/export/exporters/json.ts
@@ -1,10 +1,11 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toJson(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   const colors = {
-    source: "rootloops.sh",
+    source: `https://rootloops.sh?${queryString}`,
     hex: {
       background: cereals.background.color_hex,
       foreground: cereals.foreground.color_hex,

--- a/src/lib/export/exporters/kitty.ts
+++ b/src/lib/export/exporters/kitty.ts
@@ -1,13 +1,14 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toKitty(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `# Copy the configuration below and add it to your
 # ~/.config/kitty/kitty.conf file
 
 ## Root Loops color scheme
-## via https://rootloops.sh
+## via https://rootloops.sh?${queryString}
 
 # The basic colors
 background              ${cereals.background.color_hex}

--- a/src/lib/export/exporters/neovim.test.ts
+++ b/src/lib/export/exporters/neovim.test.ts
@@ -25,7 +25,7 @@ const expectedTheme = `" Store the following config under ~/.config/nvim/colors/
 " it as your colorscheme in your neovim config.
 
 " root-loops.vim -- Root Loops Vim Color Scheme.
-" Webpage:          https://rootloops.sh
+" Webpage:          https://rootloops.sh?sugar=7&colors=6&sogginess=2&flavor=2&fruit=9&milk=2
 " Description:      A neovim color scheme for cereal lovers
 
 hi clear

--- a/src/lib/export/exporters/neovim.ts
+++ b/src/lib/export/exporters/neovim.ts
@@ -1,4 +1,4 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare, type Cereals } from "$lib/cereals";
 import {
   type HighlightGroups,
@@ -156,13 +156,14 @@ function defineHighlights(cereals: Cereals): HighlightGroups {
 export function toNeovim(recipe: Recipe): string {
   const cereals = prepare(recipe);
   const highlights = defineHighlights(cereals);
+  const queryString = toQueryString(recipe);
 
   const template = `" Store the following config under ~/.config/nvim/colors/root-loops.vim
 " then load it into neovim via ':colorscheme root-loops' or by declaring
 " it as your colorscheme in your neovim config.
 
 " root-loops.vim -- Root Loops Vim Color Scheme.
-" Webpage:          https://rootloops.sh
+" Webpage:          https://rootloops.sh?${queryString}
 " Description:      A neovim color scheme for cereal lovers
 
 hi clear

--- a/src/lib/export/exporters/vim.test.ts
+++ b/src/lib/export/exporters/vim.test.ts
@@ -25,7 +25,7 @@ const expectedTheme = `" Store the following config under ~/.vim/colors/root-loo
 " it as your colorscheme in your .vimrc.
 
 " root-loops.vim -- Root Loops Vim Color Scheme.
-" Webpage:          https://rootloops.sh
+" Webpage:          https://rootloops.sh?sugar=7&colors=6&sogginess=2&flavor=2&fruit=9&milk=2
 " Description:      A vim color scheme for cereal lovers
 
 hi clear

--- a/src/lib/export/exporters/vim.ts
+++ b/src/lib/export/exporters/vim.ts
@@ -1,4 +1,4 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare, type Cereals } from "$lib/cereals";
 import {
   defineColors,
@@ -135,13 +135,14 @@ export function defineVimHighlights(cereals: Cereals): HighlightGroups {
 export function toVim(recipe: Recipe): string {
   const cereals = prepare(recipe);
   const highlights = defineVimHighlights(cereals);
+  const queryString = toQueryString(recipe);
 
   const template = `" Store the following config under ~/.vim/colors/root-loops.vim
 " then load it into vim via ':colorscheme root-loops' or by declaring
 " it as your colorscheme in your .vimrc.
 
 " root-loops.vim -- Root Loops Vim Color Scheme.
-" Webpage:          https://rootloops.sh
+" Webpage:          https://rootloops.sh?${queryString}
 " Description:      A vim color scheme for cereal lovers
 
 hi clear

--- a/src/lib/export/exporters/warp.ts
+++ b/src/lib/export/exporters/warp.ts
@@ -1,14 +1,15 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toWarp(recipe: Recipe): string {
+  const queryString = toQueryString(recipe);
   const cereals = prepare(recipe);
 
   return `# Copy the configuration below and add it to a new file under
 # ~/.warp/themes/rootloops.yaml
 # Open Warp's Settings > Appearance > Themes and select the 'Root Loops' theme.
 
-# via rootloops.sh
+# via https://rootloops.sh?${queryString}
 
 name: Root Loops
 accent: '${cereals.white.color_hex}'

--- a/src/lib/export/exporters/wezterm.ts
+++ b/src/lib/export/exporters/wezterm.ts
@@ -1,8 +1,9 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toWezTerm(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `-- Copy the configuration below and add it to your
 -- ~/.wezterm.lua or ~/.config/wezterm/wezterm.lua file
 
@@ -10,7 +11,7 @@ export function toWezTerm(recipe: Recipe): string {
 --       if you want to define your own root loops color scheme
 
 -- Root Loops color scheme
--- via https://rootloops.sh
+-- via https://rootloops.sh?${queryString}
 config.colors = {
   foreground = "${cereals.foreground.color_hex}",
   background = "${cereals.background.color_hex}",

--- a/src/lib/export/exporters/xresources.ts
+++ b/src/lib/export/exporters/xresources.ts
@@ -1,10 +1,11 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toXresources(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `! Copy the configuration below to your ~/.Xresources file
-! Root Loops (via rootloops.sh)
+! Root Loops (via https://rootloops.sh?${queryString})
 
 *.foreground:  ${cereals.foreground.color_hex}
 *.background:  ${cereals.background.color_hex}

--- a/src/lib/export/exporters/zellij.ts
+++ b/src/lib/export/exporters/zellij.ts
@@ -1,13 +1,14 @@
-import { type Recipe } from "$lib/ingredients";
+import { toQueryString, type Recipe } from "$lib/ingredients";
 import { prepare } from "$lib/cereals";
 
 export function toZellij(recipe: Recipe): string {
   const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
   return `// Copy the configuration below and add it to your
 // ~/.config/zellij/zellij.kdl file
 
 // Colors (Root Loops)
-// via rootloops.sh
+// via https://rootloops.sh?${queryString}
 themes {
    rootloops {
         fg "${cereals.foreground.color_hex}"

--- a/src/routes/Export.test.ts
+++ b/src/routes/Export.test.ts
@@ -14,7 +14,9 @@ describe("Export component", () => {
 
     expect(exportRegion).toBeInTheDocument();
     expect(code).toBeInTheDocument();
-    expect(code).toHaveTextContent(`"source": "rootloops.sh",`);
+    expect(code).toHaveTextContent(
+      `"source": "https://rootloops.sh?sugar=7&colors=6&sogginess=4&flavor=1&fruit=10&milk=0",`,
+    );
   });
 
   test("copies code to clipboard on click", async () => {
@@ -26,7 +28,9 @@ describe("Export component", () => {
     await fireEvent.click(button);
 
     const spyCall = clipboardSpy.mock.lastCall && clipboardSpy.mock.lastCall[0];
-    expect(spyCall).toContain(`"source": "rootloops.sh",`);
+    expect(spyCall).toContain(
+      `"source": "https://rootloops.sh?sugar=7&colors=6&sogginess=4&flavor=1&fruit=10&milk=0",`,
+    );
   });
 
   test("changes button text on click", async () => {
@@ -40,7 +44,10 @@ describe("Export component", () => {
   });
 
   test.each([
-    ["JSON", `"source": "rootloops.sh",`],
+    [
+      "JSON",
+      `"source": "https://rootloops.sh?sugar=7&colors=6&sogginess=4&flavor=1&fruit=10&milk=0",`,
+    ],
     ["WindowsTerminal", `"name": "Root Loops",`],
     ["Alacritty", `# ~/.config/alacritty/alacritty.toml file`],
     ["Xresources", `! Copy the configuration below to your ~/.Xresources file`],


### PR DESCRIPTION
This adds the query string to the exports, so if you copy-paste it into your local config, you get a convenient link back to the theme on rootloops.sh. Just a draft PR, to see if this is something you'd be interested to have :-) I've only implemented the Helix and JSON exporters as examples.