### PR TITLE
add vscode terminal export format

### DIFF
--- a/src/lib/export/exporters/exporters.test.ts
+++ b/src/lib/export/exporters/exporters.test.ts
@@ -13,6 +13,7 @@ import { toZellij } from "./zellij";
 import { type Recipe, MilkAmount, Flavor, Fruit } from "$lib/ingredients";
 import { toFzf } from "./fzf";
 import { toWarp } from "./warp";
+import { toVSCode } from "./vscode";
 
 describe("export", () => {
   const someRecipe: Recipe = {
@@ -985,5 +986,33 @@ terminal_colors:
     yellow: '#4b4536'`
 
     expect(config).toBe(expected);
+  });
+
+  it("to Visual Studio Code", () => {
+    const config = toVSCode(someRecipe);
+    const expected = {
+      "workbench.colorCustomizations": {
+        "terminal.ansiBlack": "#d0d4e1",
+        "terminal.ansiBlue": "#3f4557",
+        "terminal.ansiBrightBlack": "#959eb5",
+        "terminal.ansiBrightBlue": "#51586e",
+        "terminal.ansiBrightCyan": "#475e62",
+        "terminal.ansiBrightGreen": "#4d5e50",
+        "terminal.ansiBrightMagenta": "#655263",
+        "terminal.ansiBrightRed": "#6b524e",
+        "terminal.ansiBrightWhite": "#07080d",
+        "terminal.ansiBrightYellow": "#5f5946",
+        "terminal.ansiCyan": "#374a4d",
+        "terminal.ansiGreen": "#3c4a3e",
+        "terminal.ansiMagenta": "#50404e",
+        "terminal.ansiRed": "#55403c",
+        "terminal.ansiWhite": "#4a5165",
+        "terminal.ansiYellow": "#4b4536",
+        "terminal.background": "#dfe2eb",
+        "terminal.foreground": "#1e222d",
+        "terminalCursor.foreground": "#4a5165",
+      },
+    };
+    expect(JSON.parse(config)).toStrictEqual(expected);
   });
 });

--- a/src/lib/export/exporters/vscode.ts
+++ b/src/lib/export/exporters/vscode.ts
@@ -1,0 +1,30 @@
+import { type Recipe } from "$lib/ingredients";
+import { prepare } from "$lib/cereals";
+
+export function toVSCode(recipe: Recipe): string {
+  const cereals = prepare(recipe);
+  const colors = {
+    "workbench.colorCustomizations": {
+      "terminal.ansiBlack": cereals.black.color_hex,
+      "terminal.ansiBlue": cereals.blue.color_hex,
+      "terminal.ansiBrightBlack": cereals.brightBlack.color_hex,
+      "terminal.ansiBrightBlue": cereals.brightBlue.color_hex,
+      "terminal.ansiBrightCyan": cereals.brightCyan.color_hex,
+      "terminal.ansiBrightGreen": cereals.brightGreen.color_hex,
+      "terminal.ansiBrightMagenta": cereals.brightMagenta.color_hex,
+      "terminal.ansiBrightRed": cereals.brightRed.color_hex,
+      "terminal.ansiBrightWhite": cereals.brightWhite.color_hex,
+      "terminal.ansiBrightYellow": cereals.brightYellow.color_hex,
+      "terminal.ansiCyan": cereals.cyan.color_hex,
+      "terminal.ansiGreen": cereals.green.color_hex,
+      "terminal.ansiMagenta": cereals.magenta.color_hex,
+      "terminal.ansiRed": cereals.red.color_hex,
+      "terminal.ansiWhite": cereals.white.color_hex,
+      "terminal.ansiYellow": cereals.yellow.color_hex,
+      "terminal.background": cereals.background.color_hex,
+      "terminal.foreground": cereals.foreground.color_hex,
+      "terminalCursor.foreground": cereals.white.color_hex,
+    },
+  };
+  return JSON.stringify(colors, null, 2);
+}

--- a/src/lib/export/formats.ts
+++ b/src/lib/export/formats.ts
@@ -10,6 +10,7 @@ import { toJson } from "./exporters/json";
 import { toKitty } from "./exporters/kitty";
 import { toNeovim } from "./exporters/neovim";
 import { toVim } from "./exporters/vim";
+import { toVSCode } from "./exporters/vscode";
 import { toWarp } from "./exporters/warp";
 import { toWezTerm } from "./exporters/wezterm";
 import { toWindowsTerminal } from "./exporters/windows-terminal";
@@ -30,6 +31,7 @@ export const exporters = {
   Kitty: { export: toKitty },
   neovim: { export: toNeovim },
   vim: { export: toVim },
+  VSCode: { export: toVSCode },
   Warp: { export: toWarp },
   WezTerm: { export: toWezTerm },
   WindowsTerminal: { export: toWindowsTerminal },
@@ -59,6 +61,7 @@ export const exportSelectOptions: ExportOption[] = [
   { value: "Warp", label: "Warp", group: "Terminal Emulators" },
   { value: "WezTerm", label: "WezTerm", group: "Terminal Emulators" },
   { value: "WindowsTerminal", label: "Windows Terminal", group: "Terminal Emulators" },
+  { value: "VSCode", label: "Visual Studio Code", group: "Terminal Emulators" },
   { value: "Xresources", label: "Xresources", group: "Terminal Emulators" },
   { value: "fzf", label: "fzf", group: "CLI Tools" },
   { value: "Helix", label: "Helix", group: "CLI Tools" },

--- a/src/routes/Export.test.ts
+++ b/src/routes/Export.test.ts
@@ -52,6 +52,7 @@ describe("Export component", () => {
     ["Alacritty", `# ~/.config/alacritty/alacritty.toml file`],
     ["Xresources", `! Copy the configuration below to your ~/.Xresources file`],
     ["Kitty", `# ~/.config/kitty/kitty.conf file`],
+    ["VSCode", `"workbench.colorCustomizations": {`],
     ["Warp", `# Copy the configuration below and add it to a new file under`],
     ["WezTerm", `-- ~/.wezterm.lua or ~/.config/wezterm/wezterm.lua file`],
     ["Helix", `# Copy the configuration below to ~/.config/helix/themes/rootloops.toml`],

--- a/src/routes/Select.svelte
+++ b/src/routes/Select.svelte
@@ -59,7 +59,7 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
-    padding: 0.5rem 0.6rem;
+    padding: 0.5rem 1.8rem;
     font-size: 1rem;
     cursor: pointer;
     color: var(--color-slate-900);


### PR DESCRIPTION
Hello! This PR adds an exporter for the terminal that is built-in to Visual Studio Code.

I also had to bump the padding up on the select box as "Visual Studio Code" is a longer name than anything else in there at the moment.