### PR TITLE
Add export to Konsole .colorscheme

### DIFF
--- a/src/lib/export/formats.ts
+++ b/src/lib/export/formats.ts
@@ -8,6 +8,7 @@ import { toHelix } from "./helix";
 import { toITerm } from "./iterm";
 import { toJson } from "./json";
 import { toKitty } from "./kitty";
+import { toKonsole } from "./konsole";
 import { toNeovim } from "./neovim";
 import { toNix } from "./nix";
 import { toTabby } from "./tabby";
@@ -31,6 +32,7 @@ export const exporters = {
   iTerm: { export: toITerm },
   JSON: { export: toJson },
   Kitty: { export: toKitty },
+  Konsole: { export: toKonsole },
   neovim: { export: toNeovim },
   Nix: { export: toNix },
   Tabby: { export: toTabby },
@@ -63,6 +65,7 @@ export const exportSelectOptions: ExportOption[] = [
   { value: "Ghostty", label: "ghostty", group: "Terminal Emulators" },
   { value: "iTerm", label: "iTerm2", group: "Terminal Emulators" },
   { value: "Kitty", label: "kitty", group: "Terminal Emulators" },
+  { value: "Konsole", label: "Konsole", group: "Terminal Emulators" },
   { value: "Tabby", label: "Tabby", group: "Terminal Emulators" },
   { value: "Warp", label: "Warp", group: "Terminal Emulators" },
   { value: "WezTerm", label: "WezTerm", group: "Terminal Emulators" },

--- a/src/lib/export/konsole.test.ts
+++ b/src/lib/export/konsole.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { type Recipe, MilkAmount, Flavor, Fruit } from "$lib/ingredients";
+import { toKonsole } from "./konsole";
+
+describe("Konsole export", () => {
+  const someRecipe: Recipe = {
+    milkAmount: MilkAmount.Glug,
+    flavor: Flavor.Intense,
+    artificialColors: 2,
+    sugar: 3,
+    fruit: Fruit.Elderberry,
+    sogginess: 2,
+  };
+
+  it("exports the correct format", () => {
+    const config = toKonsole(someRecipe);
+    // prettier-ignore
+    const expected = `# Save this configuration to
+# ~/.local/share/konsole/rootloops.colorscheme
+
+# Colors (Root Loops)
+# via https://rootloops.sh?sugar=3&colors=2&sogginess=2&flavor=2&fruit=9&milk=2
+
+[Background]
+Color=230,232,239
+
+[BackgroundFaint]
+Color=230,232,239
+
+[BackgroundIntense]
+Color=230,232,239
+
+[Color0]
+Color=213,217,229
+
+[Color0Faint]
+Color=213,217,229
+
+[Color0Intense]
+Color=159,167,190
+
+[Color1]
+Color=85,64,61
+
+[Color1Faint]
+Color=85,64,61
+
+[Color1Intense]
+Color=107,83,78
+
+[Color2]
+Color=60,74,63
+
+[Color2Faint]
+Color=60,74,63
+
+[Color2Intense]
+Color=78,95,80
+
+[Color3]
+Color=75,70,54
+
+[Color3Faint]
+Color=75,70,54
+
+[Color3Intense]
+Color=96,89,71
+
+[Color4]
+Color=63,69,87
+
+[Color4Faint]
+Color=63,69,87
+
+[Color4Intense]
+Color=81,89,110
+
+[Color5]
+Color=80,64,78
+
+[Color5Faint]
+Color=80,64,78
+
+[Color5Intense]
+Color=102,82,99
+
+[Color6]
+Color=55,74,77
+
+[Color6Faint]
+Color=55,74,77
+
+[Color6Intense]
+Color=71,94,98
+
+[Color7]
+Color=78,85,106
+
+[Color7Faint]
+Color=78,85,106
+
+[Color7Intense]
+Color=38,42,55
+
+[Foreground]
+Color=15,18,25
+
+[ForegroundFaint]
+Color=15,18,25
+
+[ForegroundIntense]
+Color=15,18,25
+
+[General]
+Anchor=0.5,0.5
+Blur=true
+Description=RootLoops
+FillStyle=Tile
+Opacity=1
+Wallpaper=
+WallpaperFlipType=NoFlip
+WallpaperOpacity=1
+`;
+
+    expect(config).toBe(expected);
+  });
+});

--- a/src/lib/export/konsole.ts
+++ b/src/lib/export/konsole.ts
@@ -1,0 +1,123 @@
+import { toQueryString, type Recipe } from "$lib/ingredients";
+import { prepare, type Cereal } from "$lib/cereals";
+
+/**
+ * Formats a color as "RRR,GGG,BBB"
+ */
+function rgbstr(color: Cereal): string {
+  return [color.color_rgb.r, color.color_rgb.g, color.color_rgb.b]
+    .map((n) => Math.round(n * 256).toFixed(0))
+    .join(",");
+}
+
+export function toKonsole(recipe: Recipe): string {
+  const cereals = prepare(recipe);
+  const queryString = toQueryString(recipe);
+
+  return `# Save this configuration to
+# ~/.local/share/konsole/rootloops.colorscheme
+
+# Colors (Root Loops)
+# via https://rootloops.sh?${queryString}
+
+[Background]
+Color=${rgbstr(cereals.background)}
+
+[BackgroundFaint]
+Color=${rgbstr(cereals.background)}
+
+[BackgroundIntense]
+Color=${rgbstr(cereals.background)}
+
+[Color0]
+Color=${rgbstr(cereals.black)}
+
+[Color0Faint]
+Color=${rgbstr(cereals.black)}
+
+[Color0Intense]
+Color=${rgbstr(cereals.brightBlack)}
+
+[Color1]
+Color=${rgbstr(cereals.red)}
+
+[Color1Faint]
+Color=${rgbstr(cereals.red)}
+
+[Color1Intense]
+Color=${rgbstr(cereals.brightRed)}
+
+[Color2]
+Color=${rgbstr(cereals.green)}
+
+[Color2Faint]
+Color=${rgbstr(cereals.green)}
+
+[Color2Intense]
+Color=${rgbstr(cereals.brightGreen)}
+
+[Color3]
+Color=${rgbstr(cereals.yellow)}
+
+[Color3Faint]
+Color=${rgbstr(cereals.yellow)}
+
+[Color3Intense]
+Color=${rgbstr(cereals.brightYellow)}
+
+[Color4]
+Color=${rgbstr(cereals.blue)}
+
+[Color4Faint]
+Color=${rgbstr(cereals.blue)}
+
+[Color4Intense]
+Color=${rgbstr(cereals.brightBlue)}
+
+[Color5]
+Color=${rgbstr(cereals.magenta)}
+
+[Color5Faint]
+Color=${rgbstr(cereals.magenta)}
+
+[Color5Intense]
+Color=${rgbstr(cereals.brightMagenta)}
+
+[Color6]
+Color=${rgbstr(cereals.cyan)}
+
+[Color6Faint]
+Color=${rgbstr(cereals.cyan)}
+
+[Color6Intense]
+Color=${rgbstr(cereals.brightCyan)}
+
+[Color7]
+Color=${rgbstr(cereals.white)}
+
+[Color7Faint]
+Color=${rgbstr(cereals.white)}
+
+[Color7Intense]
+Color=${rgbstr(cereals.brightWhite)}
+
+[Foreground]
+Color=${rgbstr(cereals.foreground)}
+
+[ForegroundFaint]
+Color=${rgbstr(cereals.foreground)}
+
+[ForegroundIntense]
+Color=${rgbstr(cereals.foreground)}
+
+[General]
+Anchor=0.5,0.5
+Blur=true
+Description=RootLoops
+FillStyle=Tile
+Opacity=1
+Wallpaper=
+WallpaperFlipType=NoFlip
+WallpaperOpacity=1
+`;
+}


### PR DESCRIPTION
Thanks for a great resource!
I made a quick exporter for the Konsole .colorscheme config format.

Konsole has the concept of "faint" colors. I didn't know what to do here, so I used the normal color instead.
For the "intense" colors I used the "bright" colors from root-loops.

There might also be a cleaner way to get the RGB string used by Konsole, but what I did seems pretty straight forward to me.